### PR TITLE
Support additional source sets and custom publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,61 @@ The credentials and connection url must be specified as a project property or an
 
 By default, a `release` or `snapshot` build is determined by the `project.version` or `projectVersion` gradle property. To override this behavior, use the environment variable `GRAILS_PUBLISH_RELEASE` with a boolean value to indicate if the build is a `release` or `snapshot`.
 
+### Additional Publications
+
+A project can publish companion artifacts under their own Maven coordinates — for example a `-cli`
+artifact built from a dedicated `cli` source set — alongside the primary publication. Each additional
+publication has its own pom & Gradle module metadata, so its dependency graph stays off the primary
+artifact entirely, and it is signed and staged exactly like the primary publication. Sources and
+javadoc (groovydoc for Groovy source sets) jars are created automatically from the publication's
+source set, as required by Maven Central.
+
+The build must supply a software component holding the variants to publish. The typical setup uses a
+[feature variant](https://docs.gradle.org/current/userguide/feature_variants.html) whose configurations
+are exposed through an [adhoc component](https://docs.gradle.org/current/userguide/publishing_customization.html#sec:publishing-custom-components)
+and skipped from the default `java` component:
+
+```groovy
+sourceSets {
+    cli
+}
+
+java {
+    registerFeature('cli') {
+        usingSourceSet(sourceSets.cli)
+        capability(project.group.toString(), "${project.name}-cli", project.version.toString())
+    }
+}
+
+// keep the cli variants out of the primary publication
+components.java.withVariantsFromConfiguration(configurations.cliApiElements) { skip() }
+components.java.withVariantsFromConfiguration(configurations.cliRuntimeElements) { skip() }
+
+// expose the cli variants as their own component named `cli`
+// (requires a small plugin class to inject SoftwareComponentFactory — see
+// src/functionalTest/resources/publish-projects/other-artifacts/additional-publication)
+
+grailsPublish {
+    // ... primary configuration ...
+
+    additionalPublication('cli') {
+        // all optional — the defaults derive from the publication name:
+        artifactId = "${project.name}-cli"   // the published coordinate
+        componentName = 'cli'                // the software component to publish
+        sourceSetName = 'cli'                // used for the sources & javadoc jars
+        desc = 'The cli companion artifact'  // defaults to the primary description
+    }
+}
+```
+
+Because one project now publishes multiple coordinates, the plugin publishes the primary component as
+the root of a component tree with each additional publication's component as a child (the same model
+Kotlin Multiplatform uses). The primary Gradle module metadata therefore lists the additional
+variants as `available-at` redirects to their own coordinates; those variants carry the feature's
+capability, so consumers that do not explicitly request the capability are unaffected. This component
+tree is also what allows Gradle to resolve a project dependency (including a self dependency such as
+`cliApi project(path)`) on a project with multiple publications.
+
 ### Release Signing
 
 `release` builds are expected to be signed by this build. To disable this behavior, add the following Gradle code: 

--- a/plugin/src/functionalTest/groovy/org/apache/grails/gradle/publish/AdditionalPublicationSpec.groovy
+++ b/plugin/src/functionalTest/groovy/org/apache/grails/gradle/publish/AdditionalPublicationSpec.groovy
@@ -1,0 +1,140 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.grails.gradle.publish
+
+import org.gradle.testkit.runner.GradleRunner
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.jar.JarFile
+
+class AdditionalPublicationSpec extends GradleSpecification {
+
+    List<File> toCleanup = []
+
+    def cleanup() {
+        for (File file : toCleanup) {
+            try {
+                file.deleteDir()
+            }
+            catch (ignored) {
+            }
+        }
+    }
+
+    def "additional publication publishes a companion artifact with its own coordinate and dependency graph"() {
+        given:
+        File tempDir = File.createTempDir("additional-publication")
+        toCleanup << tempDir
+
+        and:
+        GradleRunner runner = setupTestResourceProject('other-artifacts', 'additional-publication')
+
+        runner = setGradleProperty("projectVersion", "0.0.1-SNAPSHOT", runner)
+        runner = setGradleProperty("mavenPublishUrl", tempDir.toPath().toAbsolutePath().toString(), runner)
+        runner = addEnvironmentVariable("GRAILS_PUBLISH_RELEASE", "false", runner)
+
+        when:
+        def result = executeTask("publish", ["--info"], runner)
+
+        then: "the docs jars of both publications are built"
+        assertTaskSuccess("sourcesJar", result)
+        assertTaskSuccess("javadocJar", result)
+        assertTaskSuccess("cliSourcesJar", result)
+        assertTaskSuccess("cliGroovydoc", result)
+        assertTaskSuccess("cliJavadocJar", result)
+
+        and: "the primary artifact publishes under the project coordinate"
+        Path mainArtifactDir = tempDir.toPath().resolve("org/grails/example/additional-publication/0.0.1-SNAPSHOT")
+        Files.exists(mainArtifactDir)
+        File[] mainArtifacts = mainArtifactDir.toFile().listFiles()
+
+        File mainPomFile = mainArtifacts.find { it.name.endsWith(".pom") }
+        mainPomFile
+
+        and: "the primary pom has no trace of the cli tier"
+        String mainPom = mainPomFile.text
+        !mainPom.contains("commons-lang3")
+        !mainPom.contains("additional-publication-cli")
+
+        and: "the primary module metadata carries no cli dependencies; the cli variants are only available-at redirects to the cli coordinate"
+        File mainModuleFile = mainArtifacts.find { it.name.endsWith(".module") }
+        mainModuleFile
+        String mainModule = mainModuleFile.text
+        !mainModule.contains("commons-lang3")
+        mainModule.contains('"name": "cliApiElements"')
+        mainModule.contains('"available-at"')
+        mainModule.contains('"module": "additional-publication-cli"')
+
+        and: "the primary sources jar contains only the non-cli sources"
+        File mainSourcesJar = mainArtifacts.find { it.name.endsWith("-sources.jar") }
+        mainSourcesJar
+        findJarFileEntry("org/grails/example/MyProject.groovy", mainSourcesJar)
+        !findJarFileEntry("org/grails/example/cli/MyCommand.groovy", mainSourcesJar)
+
+        and: "the primary classes jar contains only the non-cli classes"
+        File mainClassesJar = mainArtifacts.find {
+            it.name.endsWith(".jar") && !it.name.endsWith("-sources.jar") && !it.name.endsWith("-javadoc.jar")
+        }
+        mainClassesJar
+        findJarFileEntry("org/grails/example/MyProject.class", mainClassesJar)
+        !findJarFileEntry("org/grails/example/cli/MyCommand.class", mainClassesJar)
+
+        and: "the companion artifact publishes under its own -cli coordinate"
+        Path cliArtifactDir = tempDir.toPath().resolve("org/grails/example/additional-publication-cli/0.0.1-SNAPSHOT")
+        Files.exists(cliArtifactDir)
+        File[] cliArtifacts = cliArtifactDir.toFile().listFiles()
+
+        File cliClassesJar = cliArtifacts.find {
+            it.name.endsWith(".jar") && !it.name.endsWith("-sources.jar") && !it.name.endsWith("-javadoc.jar")
+        }
+        cliClassesJar
+        findJarFileEntry("org/grails/example/cli/MyCommand.class", cliClassesJar)
+        !findJarFileEntry("org/grails/example/MyProject.class", cliClassesJar)
+
+        and: "the companion pom carries the cli dependency graph, including the primary coordinate"
+        File cliPomFile = cliArtifacts.find { it.name.endsWith(".pom") }
+        cliPomFile
+        String cliPom = cliPomFile.text.replaceAll('\\n', '').replaceAll('\\s+', ' ')
+        cliPom.contains("<artifactId>additional-publication</artifactId>")
+        cliPom.contains("<artifactId>commons-lang3</artifactId>")
+        cliPom.contains("<description>The cli companion artifact of the example project</description>")
+
+        and: "every companion pom dependency has a resolved version"
+        !cliPom.contains("<version></version>")
+        cliPom.contains("<version>3.17.0</version>")
+
+        and: "the companion sources and javadoc jars contain only the cli tier"
+        File cliSourcesJar = cliArtifacts.find { it.name.endsWith("-sources.jar") }
+        cliSourcesJar
+        findJarFileEntry("org/grails/example/cli/MyCommand.groovy", cliSourcesJar)
+        !findJarFileEntry("org/grails/example/MyProject.groovy", cliSourcesJar)
+
+        File cliJavadocJar = cliArtifacts.find { it.name.endsWith("-javadoc.jar") }
+        cliJavadocJar
+        findJarFileEntry("org/grails/example/cli/MyCommand.html", cliJavadocJar)
+    }
+
+    boolean findJarFileEntry(String path, File file) {
+        try (JarFile jarFile = new JarFile(file)) {
+            return jarFile.getEntry(path) != null
+        }
+    }
+}

--- a/plugin/src/functionalTest/resources/publish-projects/other-artifacts/additional-publication/build.gradle
+++ b/plugin/src/functionalTest/resources/publish-projects/other-artifacts/additional-publication/build.gradle
@@ -1,0 +1,104 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+buildscript {
+    repositories {
+        maven { url "${System.getenv('LOCAL_MAVEN_PATH')}" }
+        maven { url = 'https://repo.grails.org/grails/restricted' }
+    }
+    dependencies {
+        classpath "org.apache.grails.gradle:grails-publish:$grailsGradlePluginVersion"
+    }
+}
+
+allprojects {
+    repositories {
+        maven { url = 'https://repo.grails.org/grails/restricted' }
+    }
+}
+
+version = projectVersion
+group = 'org.grails.example'
+
+apply plugin: 'java-library'
+apply plugin: 'groovy'
+
+// A `cli` source set published as a companion artifact under its own coordinate
+// (`additional-publication-cli`), with its own dependency graph
+sourceSets {
+    cli
+}
+
+java {
+    registerFeature('cli') {
+        usingSourceSet(sourceSets.cli)
+        capability('org.grails.example', 'additional-publication-cli', project.version.toString())
+    }
+}
+
+// Keep the cli variants out of the default `java` component so the primary publication
+// carries no trace of the cli tier
+components.java.withVariantsFromConfiguration(configurations.cliApiElements) { skip() }
+components.java.withVariantsFromConfiguration(configurations.cliRuntimeElements) { skip() }
+
+// Publish the cli variants as their own software component
+abstract class CliComponentPlugin implements Plugin<Project> {
+    @javax.inject.Inject
+    abstract org.gradle.api.component.SoftwareComponentFactory getSoftwareComponentFactory()
+
+    void apply(Project project) {
+        def cliComponent = softwareComponentFactory.adhoc('cli')
+        project.components.add(cliComponent)
+        cliComponent.addVariantsFromConfiguration(project.configurations.cliApiElements) {
+            it.mapToMavenScope('compile')
+        }
+        cliComponent.addVariantsFromConfiguration(project.configurations.cliRuntimeElements) {
+            it.mapToMavenScope('runtime')
+        }
+    }
+}
+apply plugin: CliComponentPlugin
+
+dependencies {
+    implementation "org.apache.groovy:groovy:$groovyVersion"
+
+    // the cli tier builds on the module's own default artifact
+    cliApi project(path)
+    cliImplementation "org.apache.groovy:groovy:$groovyVersion"
+    // a cli-only dependency that must never appear in the primary publication
+    cliImplementation 'org.apache.commons:commons-lang3:3.17.0'
+}
+
+apply plugin: 'org.apache.grails.gradle.grails-publish'
+grailsPublish {
+    githubSlug = 'apache/grails-cores'
+    license {
+        name = 'Apache-2.0'
+    }
+    title = 'Grails Gradle Plugin - Example Project'
+    desc = 'A testing project for the grails gradle plugin'
+    developers = [
+            jdaugherty: 'James Daugherty',
+    ]
+
+    additionalPublication('cli') {
+        // conventions: artifactId 'additional-publication-cli', component 'cli', source set 'cli'
+        desc = 'The cli companion artifact of the example project'
+    }
+}

--- a/plugin/src/functionalTest/resources/publish-projects/other-artifacts/additional-publication/gradle.properties
+++ b/plugin/src/functionalTest/resources/publish-projects/other-artifacts/additional-publication/gradle.properties
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+projectVersion=0.0.1-SNAPSHOT

--- a/plugin/src/functionalTest/resources/publish-projects/other-artifacts/additional-publication/settings.gradle
+++ b/plugin/src/functionalTest/resources/publish-projects/other-artifacts/additional-publication/settings.gradle
@@ -1,0 +1,20 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+rootProject.name = 'additional-publication'

--- a/plugin/src/functionalTest/resources/publish-projects/other-artifacts/additional-publication/src/cli/groovy/org/grails/example/cli/MyCommand.groovy
+++ b/plugin/src/functionalTest/resources/publish-projects/other-artifacts/additional-publication/src/cli/groovy/org/grails/example/cli/MyCommand.groovy
@@ -1,0 +1,33 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.example.cli
+
+import org.apache.commons.lang3.StringUtils
+
+import org.grails.example.MyProject
+
+/**
+ * A command published only by the cli companion publication
+ */
+class MyCommand {
+
+    String run(String name) {
+        new MyProject().greet(StringUtils.capitalize(name))
+    }
+}

--- a/plugin/src/functionalTest/resources/publish-projects/other-artifacts/additional-publication/src/main/groovy/org/grails/example/MyProject.groovy
+++ b/plugin/src/functionalTest/resources/publish-projects/other-artifacts/additional-publication/src/main/groovy/org/grails/example/MyProject.groovy
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.example
+
+/**
+ * The runtime library published by the primary publication
+ */
+class MyProject {
+
+    String greet(String name) {
+        "Hello, $name!"
+    }
+}

--- a/plugin/src/main/groovy/org/apache/grails/gradle/publish/AdditionalPublication.groovy
+++ b/plugin/src/main/groovy/org/apache/grails/gradle/publish/AdditionalPublication.groovy
@@ -1,0 +1,101 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.grails.gradle.publish
+
+import groovy.transform.CompileStatic
+import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+
+/**
+ * An additional publication published alongside the primary publication under its own Maven
+ * coordinate with its own dependency graph — for example a companion `-cli` artifact built from
+ * a dedicated source set of the same project.
+ */
+@CompileStatic
+class AdditionalPublication {
+
+    /**
+     * The name of the Gradle publication; must be unique within the project
+     */
+    final String name
+
+    /**
+     * The artifactId of the published artifact, defaults to "${project.name}-${name}"
+     */
+    final Property<String> artifactId
+
+    /**
+     * The software component to publish; the component must exist by the time the project is
+     * evaluated (e.g. created via SoftwareComponentFactory.adhoc). Defaults to the publication name.
+     */
+    final Property<String> componentName
+
+    /**
+     * The source set the publication is built from; used to create the sources & javadoc jars.
+     * Defaults to the publication name.
+     */
+    final Property<String> sourceSetName
+
+    /**
+     * The compile classpath configuration used to resolve dependency versions in the pom;
+     * derived from the source set name by default
+     */
+    final Property<String> compileClasspathName
+
+    /**
+     * The runtime classpath configuration used for version mapping and to resolve dependency
+     * versions in the pom; derived from the source set name by default
+     */
+    final Property<String> runtimeClasspathName
+
+    /**
+     * Title of the publication, defaults to the primary publication's title
+     */
+    final Property<String> title
+
+    /**
+     * Description of the publication, defaults to the primary publication's description
+     */
+    final Property<String> desc
+
+    /**
+     * An optional closure to be invoked via pom.withXml { } to allow further customization of
+     * this publication's pom
+     */
+    final Property<Closure> pomCustomization
+
+    AdditionalPublication(String name, ObjectFactory objects, Project project, GrailsPublishExtension extension) {
+        this.name = name
+        artifactId = objects.property(String).convention(project.provider {
+            "${project.name}-${name}" as String
+        })
+        componentName = objects.property(String).convention(name)
+        sourceSetName = objects.property(String).convention(name)
+        compileClasspathName = objects.property(String).convention(sourceSetName.map { String sourceSet ->
+            sourceSet + 'CompileClasspath'
+        })
+        runtimeClasspathName = objects.property(String).convention(sourceSetName.map { String sourceSet ->
+            sourceSet + 'RuntimeClasspath'
+        })
+        title = objects.property(String).convention(extension.title)
+        desc = objects.property(String).convention(extension.desc)
+        pomCustomization = objects.property(Closure).convention(null as Closure)
+    }
+}

--- a/plugin/src/main/groovy/org/apache/grails/gradle/publish/GrailsPublishExtension.groovy
+++ b/plugin/src/main/groovy/org/apache/grails/gradle/publish/GrailsPublishExtension.groovy
@@ -136,6 +136,12 @@ class GrailsPublishExtension {
      */
     final Property<Boolean> transitiveDependencies
 
+    /**
+     * Additional publications published alongside the primary publication, each under its own
+     * artifactId with its own dependency graph; registered via {@link #additionalPublication}
+     */
+    final List<AdditionalPublication> additionalPublications = []
+
     private ObjectFactory objects
     private Project project
 
@@ -241,6 +247,40 @@ class GrailsPublishExtension {
         MavenPomDeveloper dev = objects.newInstance(MavenPomDeveloper)
         action.execute(dev)
         developers.add(dev)
+    }
+
+    /**
+     * Registers an additional publication published alongside the primary publication under its
+     * own artifactId, built from a named software component (and source set for the sources &
+     * javadoc jars). By convention the component, source set, and classpath configuration names
+     * all derive from the publication name.
+     *
+     * @param name the publication name, e.g. 'cli'
+     * @param action the configurer
+     */
+    void additionalPublication(String name, Action<? super AdditionalPublication> action) {
+        Objects.requireNonNull(name, 'The additional publication name must not be null')
+        if (additionalPublications.any { it.name == name }) {
+            throw new IllegalArgumentException("An additional publication named `$name` is already registered.")
+        }
+
+        AdditionalPublication publication = new AdditionalPublication(name, objects, project, this)
+        action.execute(publication)
+        additionalPublications.add(publication)
+    }
+
+    /**
+     * Registers an additional publication
+     *
+     * @see #additionalPublication(String, Action)
+     */
+    void additionalPublication(String name, @DelegatesTo(value = AdditionalPublication, strategy = Closure.DELEGATE_FIRST) Closure configurer) {
+        Action<AdditionalPublication> action = { AdditionalPublication publication ->
+            configurer.delegate = publication
+            configurer.resolveStrategy = Closure.DELEGATE_FIRST
+            configurer.call(publication)
+        } as Action<AdditionalPublication>
+        additionalPublication(name, action)
     }
 }
 

--- a/plugin/src/main/groovy/org/apache/grails/gradle/publish/GrailsPublishGradlePlugin.groovy
+++ b/plugin/src/main/groovy/org/apache/grails/gradle/publish/GrailsPublishGradlePlugin.groovy
@@ -471,26 +471,26 @@ Note: if project properties are used, the properties must be defined prior to ap
             }
 
             def license = gpe.license
-            if (license) {
-                def concreteLicense = License.LICENSES.get(license.name)
-                if (concreteLicense) {
-                    pom.licenses { MavenPomLicenseSpec licenses ->
-                        licenses.license { MavenPomLicense pomLicense ->
-                            pomLicense.name.set(concreteLicense.name)
-                            pomLicense.url.set(concreteLicense.url)
-                            pomLicense.distribution.set(concreteLicense.distribution)
-                        }
+            def concreteLicense = License.LICENSES.get(license?.name)
+            if (concreteLicense) {
+                pom.licenses { MavenPomLicenseSpec licenses ->
+                    licenses.license { MavenPomLicense pomLicense ->
+                        pomLicense.name.set(concreteLicense.name)
+                        pomLicense.url.set(concreteLicense.url)
+                        pomLicense.distribution.set(concreteLicense.distribution)
                     }
-                } else if (license.name && license.url) {
-                    pom.licenses { MavenPomLicenseSpec licenses ->
-                        licenses.license { MavenPomLicense pomLicense ->
-                            pomLicense.name.set(license.name)
-                            pomLicense.url.set(license.url)
-                            pomLicense.distribution.set(license.distribution)
-                        }
+                }
+            } else if (license?.name && license?.url) {
+                pom.licenses { MavenPomLicenseSpec licenses ->
+                    licenses.license { MavenPomLicense pomLicense ->
+                        pomLicense.name.set(license.name)
+                        pomLicense.url.set(license.url)
+                        pomLicense.distribution.set(license.distribution)
                     }
                 }
             } else {
+                // a known license name, or an explicit name + url pair, is required so the
+                // published pom always carries a <licenses> section
                 throw new RuntimeException(createErrorMessage('license'))
             }
 
@@ -505,9 +505,10 @@ Note: if project properties are used, the properties must be defined prior to ap
                 issue.url.set(gpe.issueTrackerUrl.get())
             }
 
-            if (gpe.developers) {
+            List<MavenPomDeveloper> developers = gpe.developers.getOrElse([])
+            if (developers) {
                 pom.developers { MavenPomDeveloperSpec devs ->
-                    for (MavenPomDeveloper source : gpe.developers.get()) {
+                    for (MavenPomDeveloper source : developers) {
                         devs.developer { MavenPomDeveloper target ->
                             cloneDeveloper(source, target)
                         }
@@ -751,6 +752,9 @@ Note: if project properties are used, the properties must be defined prior to ap
 
         def javaComponent = project.components.named('java').get()
         if (gpe.additionalPublications) {
+            if (!(javaComponent instanceof SoftwareComponentInternal)) {
+                throw new GradleException("Additional publications require the `java` component to implement SoftwareComponentInternal, but it is a ${javaComponent.class.name}. This Gradle version is not supported for additional publications.")
+            }
             // Declare the additional publications' components as children of the primary
             // component so the project's published components form a single tree — the only
             // shape Gradle can resolve a project dependency against when one project publishes

--- a/plugin/src/main/groovy/org/apache/grails/gradle/publish/GrailsPublishGradlePlugin.groovy
+++ b/plugin/src/main/groovy/org/apache/grails/gradle/publish/GrailsPublishGradlePlugin.groovy
@@ -34,7 +34,9 @@ import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.api.component.SoftwareComponent
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.plugins.ExtraPropertiesExtension
@@ -48,6 +50,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.publish.PublicationContainer
 import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenArtifact
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPomDeveloper
 import org.gradle.api.publish.maven.MavenPomDeveloperSpec
@@ -59,11 +62,13 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.gradle.api.tasks.GroovySourceDirectorySet
+import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.javadoc.Groovydoc
+import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 import org.gradle.plugins.signing.SigningPlugin
@@ -321,6 +326,12 @@ Note: if project properties are used, the properties must be defined prior to ap
                 }
 
                 pe.publications { PublicationContainer publications ->
+                    for (AdditionalPublication additional : gpe.additionalPublications) {
+                        if (additional.name == gpe.publicationName.get()) {
+                            throw new GradleException("Additional publication `${additional.name}` conflicts with the primary publication name. Rename one of the publications.")
+                        }
+                    }
+
                     publications.create(gpe.publicationName.get(), MavenPublication) { MavenPublication publication ->
                         publication.artifactId = gpe.artifactId.get()
                         publication.groupId = gpe.groupId.get()
@@ -332,117 +343,33 @@ Note: if project properties are used, the properties must be defined prior to ap
                                 publication.artifact(extraArtefact)
                             }
 
-                            // Ensure Gradle module metadata includes resolved versions for
-                            // all dependencies. Without this, dependencies declared without
-                            // an explicit version (relying on a platform/BOM) are published
-                            // with no version in the .module file, causing resolution
-                            // failures for consumers since Gradle prefers .module over .pom.
-                            if (!project.extensions.findByType(JavaPlatformExtension)) {
-                                publication.versionMapping { strategy ->
-                                    strategy.usage('java-api') { variant ->
-                                        variant.fromResolutionOf('runtimeClasspath')
-                                    }
-                                    strategy.usage('java-runtime') { variant ->
-                                        variant.fromResolutionResult()
-                                    }
-                                }
-                            }
+                            configureVersionMapping(project, publication, 'runtimeClasspath')
                         }
 
-                        publication.pom { MavenPom pom ->
-                            pom.name.set(gpe.title.get())
-                            pom.description.set(gpe.desc.get())
-                            pom.url.set(gpe.websiteUrl.get())
+                        configurePom(project, gpe, publication, gpe.title, gpe.desc, gpe.pomCustomization,
+                                ['compileClasspath', 'runtimeClasspath',
+                                 'testFixturesCompileClasspath', 'testFixturesRuntimeClasspath'])
+                    }
 
-                            def organization = gpe.organization
-                            if (organization.name.isPresent() || organization.url.isPresent()) {
-                                pom.organization { org ->
-                                    if (organization.name.isPresent()) {
-                                        org.name.set(organization.name)
-                                    }
-                                    if (organization.url.isPresent()) {
-                                        org.url.set(organization.url)
-                                    }
+                    for (AdditionalPublication additional : gpe.additionalPublications) {
+                        publications.create(additional.name, MavenPublication) { MavenPublication publication ->
+                            publication.artifactId = additional.artifactId.get()
+                            publication.groupId = gpe.groupId.get()
+
+                            if (gpe.addComponents.get()) {
+                                String componentName = additional.componentName.get()
+                                def component = project.components.findByName(componentName)
+                                if (component == null) {
+                                    throw new GradleException("Additional publication `${additional.name}` of project `${project.name}` requires a software component named `${componentName}`, but none exists. Create the component (e.g. via SoftwareComponentFactory.adhoc) before the project is evaluated, or set `componentName` to an existing component.")
                                 }
+                                publication.from(component)
+                                attachDocsJars(project, publication, additional)
+
+                                configureVersionMapping(project, publication, additional.runtimeClasspathName.get())
                             }
 
-                            def license = gpe.license
-                            if (license) {
-                                def concreteLicense = License.LICENSES.get(license.name)
-                                if (concreteLicense) {
-                                    pom.licenses { MavenPomLicenseSpec licenses ->
-                                        licenses.license { MavenPomLicense pomLicense ->
-                                            pomLicense.name.set(concreteLicense.name)
-                                            pomLicense.url.set(concreteLicense.url)
-                                            pomLicense.distribution.set(concreteLicense.distribution)
-                                        }
-                                    }
-                                } else if (license.name && license.url) {
-                                    pom.licenses { MavenPomLicenseSpec licenses ->
-                                        licenses.license { MavenPomLicense pomLicense ->
-                                            pomLicense.name.set(license.name)
-                                            pomLicense.url.set(license.url)
-                                            pomLicense.distribution.set(license.distribution)
-                                        }
-                                    }
-                                }
-                            } else {
-                                throw new RuntimeException(createErrorMessage('license'))
-                            }
-
-                            pom.scm { MavenPomScm scm ->
-                                scm.url.set(gpe.scmUrl.get())
-                                scm.connection.set(gpe.scmUrlConnection.get())
-                                scm.developerConnection.set(gpe.scmUrlConnection.get())
-                            }
-
-                            pom.issueManagement { MavenPomIssueManagement issue ->
-                                issue.system.set(gpe.issueTrackerName.get())
-                                issue.url.set(gpe.issueTrackerUrl.get())
-                            }
-
-                            if (gpe.developers) {
-                                pom.developers { MavenPomDeveloperSpec devs ->
-                                    for (MavenPomDeveloper source : gpe.developers.get()) {
-                                        devs.developer { MavenPomDeveloper target ->
-                                            cloneDeveloper(source, target)
-                                        }
-                                    }
-                                }
-                            } else {
-                                throw new RuntimeException(createErrorMessage('developers'))
-                            }
-
-                            pom.withXml { XmlProvider xml ->
-                                Node pomNode = xml.asNode()
-
-                                if (!project.extensions.findByType(JavaPlatformExtension)) {
-                                    // Spring boot dependency management plugin will add the dependencyManagement section,
-                                    // we do not want to publish this information as we will determine the specific versions
-                                    // and set them instead
-                                    NodeList dependencyManagement = (NodeList) pomNode.get('dependencyManagement')
-                                    if (dependencyManagement) {
-                                        dependencyManagement.replaceNode {}
-                                    }
-                                }
-
-                                if (gpe.pomCustomization.isPresent()) {
-                                    Closure pomCustomization = gpe.pomCustomization.get()
-                                    pomCustomization.delegate = pom
-                                    pomCustomization.resolveStrategy = Closure.DELEGATE_FIRST
-                                    pomCustomization.call(xml)
-                                }
-
-                                // fix dependencies without a version, this can occur when the spring dependency management plugin is used
-                                // disabling that plugin will cause gradle to fail on any unresolved, or by disabling the check with:
-                                // https://github.com/gradle/gradle/issues/23030
-                                //tasks.withType(GenerateModuleMetadata).configureEach {
-                                //    suppressedValidationErrors.add('dependencies-without-versions')
-                                //}
-                                if (gpe.transitiveDependencies.get()) {
-                                    setDependencyVersions(pomNode, project)
-                                }
-                            }
+                            configurePom(project, gpe, publication, additional.title, additional.desc, additional.pomCustomization,
+                                    [additional.compileClasspathName.get(), additional.runtimeClasspathName.get()])
                         }
                     }
                 }
@@ -519,7 +446,227 @@ Note: if project properties are used, the properties must be defined prior to ap
         }
     }
 
-    protected void setDependencyVersions(Node pomNode, Project project) {
+    /**
+     * Configures the pom metadata shared by every publication (primary and additional) from the
+     * extension, with the title, description, and pom customization supplied per publication.
+     */
+    protected void configurePom(Project project, GrailsPublishExtension gpe, MavenPublication publication,
+                                Provider<String> title, Provider<String> desc, Provider<Closure> pomCustomization,
+                                List<String> versionResolutionConfigurations) {
+        publication.pom { MavenPom pom ->
+            pom.name.set(title.get())
+            pom.description.set(desc.get())
+            pom.url.set(gpe.websiteUrl.get())
+
+            def organization = gpe.organization
+            if (organization.name.isPresent() || organization.url.isPresent()) {
+                pom.organization { org ->
+                    if (organization.name.isPresent()) {
+                        org.name.set(organization.name)
+                    }
+                    if (organization.url.isPresent()) {
+                        org.url.set(organization.url)
+                    }
+                }
+            }
+
+            def license = gpe.license
+            if (license) {
+                def concreteLicense = License.LICENSES.get(license.name)
+                if (concreteLicense) {
+                    pom.licenses { MavenPomLicenseSpec licenses ->
+                        licenses.license { MavenPomLicense pomLicense ->
+                            pomLicense.name.set(concreteLicense.name)
+                            pomLicense.url.set(concreteLicense.url)
+                            pomLicense.distribution.set(concreteLicense.distribution)
+                        }
+                    }
+                } else if (license.name && license.url) {
+                    pom.licenses { MavenPomLicenseSpec licenses ->
+                        licenses.license { MavenPomLicense pomLicense ->
+                            pomLicense.name.set(license.name)
+                            pomLicense.url.set(license.url)
+                            pomLicense.distribution.set(license.distribution)
+                        }
+                    }
+                }
+            } else {
+                throw new RuntimeException(createErrorMessage('license'))
+            }
+
+            pom.scm { MavenPomScm scm ->
+                scm.url.set(gpe.scmUrl.get())
+                scm.connection.set(gpe.scmUrlConnection.get())
+                scm.developerConnection.set(gpe.scmUrlConnection.get())
+            }
+
+            pom.issueManagement { MavenPomIssueManagement issue ->
+                issue.system.set(gpe.issueTrackerName.get())
+                issue.url.set(gpe.issueTrackerUrl.get())
+            }
+
+            if (gpe.developers) {
+                pom.developers { MavenPomDeveloperSpec devs ->
+                    for (MavenPomDeveloper source : gpe.developers.get()) {
+                        devs.developer { MavenPomDeveloper target ->
+                            cloneDeveloper(source, target)
+                        }
+                    }
+                }
+            } else {
+                throw new RuntimeException(createErrorMessage('developers'))
+            }
+
+            pom.withXml { XmlProvider xml ->
+                Node pomNode = xml.asNode()
+
+                if (!project.extensions.findByType(JavaPlatformExtension)) {
+                    // Spring boot dependency management plugin will add the dependencyManagement section,
+                    // we do not want to publish this information as we will determine the specific versions
+                    // and set them instead
+                    NodeList dependencyManagement = (NodeList) pomNode.get('dependencyManagement')
+                    if (dependencyManagement) {
+                        dependencyManagement.replaceNode {}
+                    }
+                }
+
+                if (pomCustomization.isPresent()) {
+                    Closure customization = pomCustomization.get()
+                    customization.delegate = pom
+                    customization.resolveStrategy = Closure.DELEGATE_FIRST
+                    customization.call(xml)
+                }
+
+                // fix dependencies without a version, this can occur when the spring dependency management plugin is used
+                // disabling that plugin will cause gradle to fail on any unresolved, or by disabling the check with:
+                // https://github.com/gradle/gradle/issues/23030
+                //tasks.withType(GenerateModuleMetadata).configureEach {
+                //    suppressedValidationErrors.add('dependencies-without-versions')
+                //}
+                if (gpe.transitiveDependencies.get()) {
+                    setDependencyVersions(pomNode, project, versionResolutionConfigurations)
+                }
+            }
+        }
+    }
+
+    /**
+     * Ensure Gradle module metadata includes resolved versions for all dependencies. Without this,
+     * dependencies declared without an explicit version (relying on a platform/BOM) are published
+     * with no version in the .module file, causing resolution failures for consumers since Gradle
+     * prefers .module over .pom.
+     */
+    protected static void configureVersionMapping(Project project, MavenPublication publication, String runtimeClasspathName) {
+        if (!project.extensions.findByType(JavaPlatformExtension)) {
+            publication.versionMapping { strategy ->
+                strategy.usage('java-api') { variant ->
+                    variant.fromResolutionOf(runtimeClasspathName)
+                }
+                strategy.usage('java-runtime') { variant ->
+                    variant.fromResolutionResult()
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates (or reuses) the sources and javadoc jars for an additional publication's source set
+     * and attaches them to the publication with the `sources`/`javadoc` classifiers required by
+     * Maven Central. The additional publication's software component must not already contain
+     * sources or javadoc variants.
+     */
+    protected void attachDocsJars(Project project, MavenPublication publication, AdditionalPublication additional) {
+        SourceSetContainer sourceSets = findSourceSets(project)
+        String sourceSetName = additional.sourceSetName.get()
+        SourceSet sourceSet = sourceSets.findByName(sourceSetName)
+        if (sourceSet == null) {
+            throw new GradleException("Additional publication `${additional.name}` of project `${project.name}` requires source set `${sourceSetName}` to build its sources and javadoc jars, but it does not exist. Set `sourceSetName` if the sources live in a differently named source set.")
+        }
+
+        TaskContainer tasks = project.tasks
+
+        TaskProvider<Jar> sourcesJarTask
+        if (tasks.names.contains(sourceSet.sourcesJarTaskName)) {
+            sourcesJarTask = tasks.named(sourceSet.sourcesJarTaskName, Jar)
+        } else {
+            sourcesJarTask = tasks.register(sourceSet.sourcesJarTaskName, Jar) { Jar jar ->
+                configureReproducibleJar(jar)
+                jar.group = BUILD_GROUP
+                jar.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+                jar.archiveBaseName.set(additional.artifactId)
+                jar.archiveClassifier.set('sources')
+                jar.from(sourceSet.allSource)
+                jar.inputs.files(sourceSet.allSource)
+            }
+        }
+        publication.artifact(sourcesJarTask) { MavenArtifact artifact ->
+            artifact.classifier = 'sources'
+        }
+
+        TaskProvider<Jar> javadocJarTask
+        if (tasks.names.contains(sourceSet.javadocJarTaskName)) {
+            javadocJarTask = tasks.named(sourceSet.javadocJarTaskName, Jar)
+        } else {
+            TaskProvider<? extends Task> docTask = registerDocTask(project, sourceSet)
+            javadocJarTask = tasks.register(sourceSet.javadocJarTaskName, Jar) { Jar jar ->
+                configureReproducibleJar(jar)
+                jar.group = BUILD_GROUP
+                jar.archiveBaseName.set(additional.artifactId)
+                jar.archiveClassifier.set('javadoc')
+                jar.from(docTask)
+            }
+        }
+        publication.artifact(javadocJarTask) { MavenArtifact artifact ->
+            artifact.classifier = 'javadoc'
+        }
+    }
+
+    /**
+     * Registers the documentation task backing an additional publication's javadoc jar —
+     * groovydoc when the source set has Groovy sources (matching how the primary javadoc jar
+     * packages groovydoc), plain javadoc otherwise.
+     */
+    private TaskProvider<? extends Task> registerDocTask(Project project, SourceSet sourceSet) {
+        TaskContainer tasks = project.tasks
+        def groovySources = sourceSet.extensions.findByType(GroovySourceDirectorySet)
+        if (groovySources != null) {
+            String taskName = "${sourceSet.name}Groovydoc"
+            if (tasks.names.contains(taskName)) {
+                return tasks.named(taskName)
+            }
+            return tasks.register(taskName, Groovydoc) { Groovydoc groovydoc ->
+                groovydoc.source(groovySources)
+                // Ensure the java sources are included in the groovydoc, matching the primary javadoc jar
+                groovydoc.source(project.files(sourceSet.java.srcDirs))
+                groovydoc.classpath = sourceSet.compileClasspath
+                groovydoc.destinationDir = project.layout.buildDirectory.dir("docs/${taskName}").get().asFile
+            }
+        }
+
+        String taskName = sourceSet.javadocTaskName
+        if (tasks.names.contains(taskName)) {
+            return tasks.named(taskName)
+        }
+        return tasks.register(taskName, Javadoc) { Javadoc javadoc ->
+            javadoc.source = sourceSet.allJava
+            javadoc.classpath = sourceSet.compileClasspath.plus(sourceSet.output)
+            javadoc.destinationDir = project.layout.buildDirectory.dir("docs/${taskName}").get().asFile
+        }
+    }
+
+    protected static void configureReproducibleJar(Jar jar) {
+        jar.reproducibleFileOrder = true
+        jar.preserveFileTimestamps = false
+        // to avoid platform specific defaults, set the permissions consistently
+        jar.filePermissions { permissions ->
+            permissions.unix(0644)
+        }
+        jar.dirPermissions { permissions ->
+            permissions.unix(0755)
+        }
+    }
+
+    protected void setDependencyVersions(Node pomNode, Project project, List<String> configurationNames) {
         def mavenPomNamespace = 'http://maven.apache.org/POM/4.0.0'
         def dependenciesQName = new QName(mavenPomNamespace, 'dependencies')
         def dependencyQName = new QName(mavenPomNamespace, 'dependency')
@@ -534,11 +681,11 @@ Note: if project properties are used, the properties must be defined prior to ap
         NodeList dependencyNodes = (nodes.get(0) as Node).getAt(dependencyQName) as NodeList
 
         LinkedHashSet<ResolvedArtifact> resolvedArtifacts = []
-        resolvedArtifacts.addAll(project.configurations.getByName('compileClasspath').resolvedConfiguration.resolvedArtifacts)
-        resolvedArtifacts.addAll(project.configurations.getByName('runtimeClasspath').resolvedConfiguration.resolvedArtifacts)
-        if (project.configurations.findByName('testFixturesCompileClasspath') != null) {
-            resolvedArtifacts.addAll(project.configurations.getByName('testFixturesCompileClasspath').resolvedConfiguration.resolvedArtifacts)
-            resolvedArtifacts.addAll(project.configurations.getByName('testFixturesRuntimeClasspath').resolvedConfiguration.resolvedArtifacts)
+        for (String configurationName : configurationNames) {
+            def configuration = project.configurations.findByName(configurationName)
+            if (configuration != null) {
+                resolvedArtifacts.addAll(configuration.resolvedConfiguration.resolvedArtifacts)
+            }
         }
 
         dependencyNodes.findAll { dependencyNode ->
@@ -590,6 +737,9 @@ Note: if project properties are used, the properties must be defined prior to ap
     protected void doAddArtefact(Project project, MavenPublication publication) {
         GrailsPublishExtension gpe = project.extensions.findByType(GrailsPublishExtension)
         if (project.extensions.findByType(JavaPlatformExtension)) {
+            if (gpe.additionalPublications) {
+                throw new RuntimeException('Additional publications are not supported for BOM publishes.')
+            }
             publication.from(project.components.named('javaPlatform').get())
 
             if (gpe.publishTestSources.get()) {
@@ -599,7 +749,25 @@ Note: if project properties are used, the properties must be defined prior to ap
             return
         }
 
-        publication.from project.components.named('java').get()
+        def javaComponent = project.components.named('java').get()
+        if (gpe.additionalPublications) {
+            // Declare the additional publications' components as children of the primary
+            // component so the project's published components form a single tree — the only
+            // shape Gradle can resolve a project dependency against when one project publishes
+            // multiple coordinates (see GrailsRootSoftwareComponent).
+            List<SoftwareComponent> childComponents = gpe.additionalPublications.collect { AdditionalPublication additional ->
+                String componentName = additional.componentName.get()
+                SoftwareComponent component = project.components.findByName(componentName)
+                if (component == null) {
+                    throw new GradleException("Additional publication `${additional.name}` of project `${project.name}` requires a software component named `${componentName}`, but none exists. Create the component (e.g. via SoftwareComponentFactory.adhoc) before the project is evaluated, or set `componentName` to an existing component.")
+                }
+                component
+            }
+            publication.from(new GrailsRootSoftwareComponent((SoftwareComponentInternal) javaComponent, childComponents))
+        } else {
+            publication.from(javaComponent)
+        }
+
         if (gpe.publishTestSources.get()) {
             publication.artifact(project.tasks.named('testSourcesJar', Jar))
         }
@@ -662,15 +830,7 @@ Note: if project properties are used, the properties must be defined prior to ap
         }
 
         tasks.named('javadocJar', Jar).configure { Jar jar ->
-            jar.reproducibleFileOrder = true
-            jar.preserveFileTimestamps = false
-            // to avoid platform specific defaults, set the permissions consistently
-            jar.filePermissions { permissions ->
-                permissions.unix(0644)
-            }
-            jar.dirPermissions { permissions ->
-                permissions.unix(0755)
-            }
+            configureReproducibleJar(jar)
 
             Groovydoc groovyDocTask = tasks.findByName('groovydoc') as Groovydoc
             if (groovyDocTask) {
@@ -688,20 +848,19 @@ Note: if project properties are used, the properties must be defined prior to ap
 
         tasks.named('sourcesJar', Jar).configure { Jar jar ->
             SourceSetContainer sourceSets = GrailsPublishGradlePlugin.findSourceSets(project)
-            jar.reproducibleFileOrder = true
-            jar.preserveFileTimestamps = false
-            // to avoid platform specific defaults, set the permissions consistently
-            jar.filePermissions { permissions ->
-                permissions.unix(0644)
-            }
-            jar.dirPermissions { permissions ->
-                permissions.unix(0755)
-            }
+            configureReproducibleJar(jar)
             jar.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
-            // don't only include main, but any source set
-            jar.from sourceSets.collect { it.allSource }
-            jar.inputs.files(sourceSets.collect { it.allSource })
+            // don't only include main, but any source set — except source sets that are
+            // published separately by an additional publication with their own sources jar
+            GrailsPublishExtension gpe = project.extensions.getByType(GrailsPublishExtension)
+            Set<String> additionalPublicationSourceSets = gpe.additionalPublications
+                    .collect { it.sourceSetName.get() } as Set<String>
+            Collection<SourceSet> publishedSourceSets = sourceSets.findAll { SourceSet sourceSet ->
+                !(sourceSet.name in additionalPublicationSourceSets)
+            }
+            jar.from publishedSourceSets.collect { it.allSource }
+            jar.inputs.files(publishedSourceSets.collect { it.allSource })
         }
 
         project.tasks.register('testSourcesJar', Jar).configure { Jar jar ->
@@ -710,15 +869,7 @@ Note: if project properties are used, the properties must be defined prior to ap
                         !jar.source.files.isEmpty()
             }
             jar.dependsOn('testClasses')
-            jar.reproducibleFileOrder = true
-            jar.preserveFileTimestamps = false
-            // to avoid platform specific defaults, set the permissions consistently
-            jar.filePermissions { permissions ->
-                permissions.unix(0644)
-            }
-            jar.dirPermissions { permissions ->
-                permissions.unix(0755)
-            }
+            configureReproducibleJar(jar)
             SourceSetContainer sourceSets = GrailsPublishGradlePlugin.findSourceSets(project)
             def testSourceSet = sourceSets.named('test').get()
             jar.from(testSourceSet.output)

--- a/plugin/src/main/groovy/org/apache/grails/gradle/publish/GrailsRootSoftwareComponent.groovy
+++ b/plugin/src/main/groovy/org/apache/grails/gradle/publish/GrailsRootSoftwareComponent.groovy
@@ -1,0 +1,68 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.grails.gradle.publish
+
+import groovy.transform.CompileStatic
+import org.gradle.api.component.ComponentWithVariants
+import org.gradle.api.component.SoftwareComponent
+import org.gradle.api.component.SoftwareComponentVariant
+import org.gradle.api.internal.component.SoftwareComponentInternal
+
+/**
+ * Wraps the primary software component when additional publications exist, declaring the
+ * additional publications' components as child components.
+ *
+ * Gradle can only resolve a project dependency on a project that publishes multiple coordinates
+ * when the published components form a single tree: one top-level component whose
+ * {@link ComponentWithVariants#getVariants() child components} carry the other coordinates
+ * (see {@code DefaultProjectDependencyPublicationResolver}). Without this wrapper, any project
+ * dependency on a project with additional publications fails metadata generation with
+ * "Publishing is not able to resolve a dependency on a project with multiple publications that
+ * have different coordinates". This is the same publication model used by Kotlin Multiplatform.
+ *
+ * As a consequence the primary publication's Gradle module metadata lists the child components'
+ * variants as {@code available-at} redirects to their own coordinates. Those variants carry the
+ * child's capabilities, so consumers that do not explicitly request them are unaffected.
+ */
+@CompileStatic
+class GrailsRootSoftwareComponent implements SoftwareComponentInternal, ComponentWithVariants {
+
+    private final SoftwareComponentInternal delegate
+    private final Set<SoftwareComponent> childComponents
+
+    GrailsRootSoftwareComponent(SoftwareComponentInternal delegate, Collection<SoftwareComponent> childComponents) {
+        this.delegate = delegate
+        this.childComponents = new LinkedHashSet<>(childComponents)
+    }
+
+    @Override
+    String getName() {
+        delegate.name
+    }
+
+    @Override
+    Set<? extends SoftwareComponentVariant> getUsages() {
+        delegate.usages
+    }
+
+    @Override
+    Set<? extends SoftwareComponent> getVariants() {
+        childComponents
+    }
+}

--- a/plugin/src/test/groovy/org/apache/grails/gradle/publish/GrailsPublishGradlePluginTest.groovy
+++ b/plugin/src/test/groovy/org/apache/grails/gradle/publish/GrailsPublishGradlePluginTest.groovy
@@ -232,6 +232,52 @@ class GrailsPublishGradlePluginTest extends Specification {
         ]
     }
 
+    def 'publishing without a license fails'() {
+        given:
+        def project = ProjectBuilder.builder().withName('test-project').build()
+        project.version = '1.0.0-SNAPSHOT'
+
+        and:
+        project.plugins.apply('org.apache.grails.gradle.grails-publish')
+        project.plugins.apply('java')
+
+        and: 'developers are configured, but no license'
+        GrailsPublishExtension gpe = project.extensions.getByType(GrailsPublishExtension)
+        gpe.githubSlug.set('apache/grails-gradle-publish')
+        gpe.developers = ['jdaugherty': 'James Daugherty']
+
+        when:
+        ((ProjectInternal) project).evaluate()
+
+        then:
+        def ge = thrown(GradleException)
+        causeChainContains(ge, "No 'license' was specified")
+    }
+
+    def 'publishing without developers fails'() {
+        given:
+        def project = ProjectBuilder.builder().withName('test-project').build()
+        project.version = '1.0.0-SNAPSHOT'
+
+        and:
+        project.plugins.apply('org.apache.grails.gradle.grails-publish')
+        project.plugins.apply('java')
+
+        and: 'a license is configured, but the developer list is empty'
+        GrailsPublishExtension gpe = project.extensions.getByType(GrailsPublishExtension)
+        gpe.githubSlug.set('apache/grails-gradle-publish')
+        gpe.license {
+            name = 'Apache-2.0'
+        }
+
+        when:
+        ((ProjectInternal) project).evaluate()
+
+        then:
+        def ge = thrown(GradleException)
+        causeChainContains(ge, "No 'developers' was specified")
+    }
+
     def 'additional publication registers a second publication with its own artifactId and docs jar tasks'() {
         given:
         def project = ProjectBuilder.builder().withName('test-project').build()

--- a/plugin/src/test/groovy/org/apache/grails/gradle/publish/GrailsPublishGradlePluginTest.groovy
+++ b/plugin/src/test/groovy/org/apache/grails/gradle/publish/GrailsPublishGradlePluginTest.groovy
@@ -20,9 +20,14 @@
 package org.apache.grails.gradle.publish
 
 import org.gradle.api.GradleException
+import org.gradle.api.component.SoftwareComponentFactory
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
+
+import javax.inject.Inject
 
 class GrailsPublishGradlePluginTest extends Specification {
 
@@ -225,5 +230,171 @@ class GrailsPublishGradlePluginTest extends Specification {
                 'updateDaemonJvm',
                 'wrapper'
         ]
+    }
+
+    def 'additional publication registers a second publication with its own artifactId and docs jar tasks'() {
+        given:
+        def project = ProjectBuilder.builder().withName('test-project').build()
+        project.version = '1.0.0-SNAPSHOT'
+
+        and:
+        project.plugins.apply('org.apache.grails.gradle.grails-publish')
+        project.plugins.apply('groovy')
+        project.sourceSets.create('cli')
+
+        and: 'a cli software component exists'
+        def componentFactoryHolder = project.objects.newInstance(ComponentFactoryHolder)
+        project.components.add(componentFactoryHolder.factory.adhoc('cli'))
+
+        and:
+        GrailsPublishExtension gpe = project.extensions.getByType(GrailsPublishExtension)
+        gpe.githubSlug.set('apache/grails-gradle-publish')
+        gpe.license {
+            name = 'Apache-2.0'
+        }
+        gpe.title.set('Grails Gradle Publish Plugin')
+        gpe.desc.set('A plugin to assist in publishing Grails artifacts')
+        gpe.developers = ['jdaugherty': 'James Daugherty']
+        gpe.additionalPublication('cli') {
+        }
+
+        when:
+        ((ProjectInternal) project).evaluate()
+
+        then:
+        def publishing = project.extensions.getByType(PublishingExtension)
+        publishing.publications.names.toSet() == ['maven', 'cli'] as Set
+
+        and: 'the artifactId defaults to the project name with the publication name appended'
+        (publishing.publications.getByName('cli') as MavenPublication).artifactId == 'test-project-cli'
+        (publishing.publications.getByName('maven') as MavenPublication).artifactId == 'test-project'
+
+        and: 'the sources, groovydoc, and javadoc jar tasks exist for the cli source set'
+        project.tasks.names.containsAll(['cliSourcesJar', 'cliGroovydoc', 'cliJavadocJar'])
+    }
+
+    def 'additional publication requires its software component to exist'() {
+        given:
+        def project = ProjectBuilder.builder().withName('test-project').build()
+        project.version = '1.0.0-SNAPSHOT'
+
+        and:
+        project.plugins.apply('org.apache.grails.gradle.grails-publish')
+        project.plugins.apply('groovy')
+        project.sourceSets.create('cli')
+
+        and:
+        GrailsPublishExtension gpe = project.extensions.getByType(GrailsPublishExtension)
+        gpe.githubSlug.set('apache/grails-gradle-publish')
+        gpe.license {
+            name = 'Apache-2.0'
+        }
+        gpe.developers = ['jdaugherty': 'James Daugherty']
+        gpe.additionalPublication('cli') {
+        }
+
+        when:
+        ((ProjectInternal) project).evaluate()
+
+        then:
+        def ge = thrown(GradleException)
+        causeChainContains(ge, 'requires a software component named `cli`')
+    }
+
+    def 'additional publication requires its source set to exist'() {
+        given:
+        def project = ProjectBuilder.builder().withName('test-project').build()
+        project.version = '1.0.0-SNAPSHOT'
+
+        and:
+        project.plugins.apply('org.apache.grails.gradle.grails-publish')
+        project.plugins.apply('groovy')
+
+        and: 'a cli software component exists, but no cli source set'
+        def componentFactoryHolder = project.objects.newInstance(ComponentFactoryHolder)
+        project.components.add(componentFactoryHolder.factory.adhoc('cli'))
+
+        and:
+        GrailsPublishExtension gpe = project.extensions.getByType(GrailsPublishExtension)
+        gpe.githubSlug.set('apache/grails-gradle-publish')
+        gpe.license {
+            name = 'Apache-2.0'
+        }
+        gpe.developers = ['jdaugherty': 'James Daugherty']
+        gpe.additionalPublication('cli') {
+        }
+
+        when:
+        ((ProjectInternal) project).evaluate()
+
+        then:
+        def ge = thrown(GradleException)
+        causeChainContains(ge, 'requires source set `cli`')
+    }
+
+    def 'additional publication name must not conflict with the primary publication'() {
+        given:
+        def project = ProjectBuilder.builder().withName('test-project').build()
+        project.version = '1.0.0-SNAPSHOT'
+
+        and:
+        project.plugins.apply('org.apache.grails.gradle.grails-publish')
+        project.plugins.apply('groovy')
+
+        and:
+        GrailsPublishExtension gpe = project.extensions.getByType(GrailsPublishExtension)
+        gpe.githubSlug.set('apache/grails-gradle-publish')
+        gpe.license {
+            name = 'Apache-2.0'
+        }
+        gpe.developers = ['jdaugherty': 'James Daugherty']
+        gpe.additionalPublication('maven') {
+        }
+
+        when:
+        ((ProjectInternal) project).evaluate()
+
+        then:
+        def ge = thrown(GradleException)
+        causeChainContains(ge, 'conflicts with the primary publication name')
+    }
+
+    def 'additional publication names must be unique'() {
+        given:
+        def project = ProjectBuilder.builder().withName('test-project').build()
+        project.version = '1.0.0-SNAPSHOT'
+
+        and:
+        project.plugins.apply('org.apache.grails.gradle.grails-publish')
+
+        and:
+        GrailsPublishExtension gpe = project.extensions.getByType(GrailsPublishExtension)
+        gpe.additionalPublication('cli') {
+        }
+
+        when:
+        gpe.additionalPublication('cli') {
+        }
+
+        then:
+        def iae = thrown(IllegalArgumentException)
+        iae.message == 'An additional publication named `cli` is already registered.'
+    }
+
+    private static boolean causeChainContains(Throwable throwable, String expected) {
+        Throwable current = throwable
+        while (current != null) {
+            if (current.message?.contains(expected)) {
+                return true
+            }
+            current = current.cause
+        }
+        false
+    }
+
+    static abstract class ComponentFactoryHolder {
+
+        @Inject
+        abstract SoftwareComponentFactory getFactory()
     }
 }


### PR DESCRIPTION
To support splitting the cli dependencies, we need to support publishing different source sets